### PR TITLE
Implemented CertificateError event

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The `Disconnected` event is raised when:
 
 The `DisconnectedEventArgs` may have an error code or error message for more information.
 
+The `CertificateError` event is raised when the TLS handshake failed. Calling `e.Continue();` in the event handler will set the `FreeRdpConfiguration.IgnoreCertificate` property to true and retries the connection.
+
 ## Exploring the Demo Application
 The demo application is quite simple. The `Connection` menu has the following items:
 ### Connect

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.Designer.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.Designer.cs
@@ -65,7 +65,7 @@
             freeRdpConfiguration1.GatewayPassword = null;
             freeRdpConfiguration1.GatewayUserName = null;
             freeRdpConfiguration1.GdiRendering = RoyalApps.Community.FreeRdp.WinForms.Configuration.GdiRendering.NotSpecified;
-            freeRdpConfiguration1.IgnoreCertificate = true;
+            freeRdpConfiguration1.IgnoreCertificate = false;
             freeRdpConfiguration1.KeyboardLayout = null;
             freeRdpConfiguration1.MenuAnimations = false;
             freeRdpConfiguration1.NetworkConnectionType = RoyalApps.Community.FreeRdp.WinForms.Configuration.NetworkConnectionType.NotSpecified;
@@ -94,6 +94,7 @@
             this.FreeRdpControl.TabIndex = 0;
             this.FreeRdpControl.Connected += FreeRdpControl_Connected;
             this.FreeRdpControl.Disconnected += FreeRdpControl_Disconnected;
+            this.FreeRdpControl.CertificateError += FreeRdpControl_CertificateError;
             //
             // MenuStrip
             // 

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.cs
@@ -115,7 +115,17 @@ public partial class FreeRdpForm : Form
         _propertyGrid.SelectedObject = FreeRdpControl.Configuration;
         if (e.UserInitiated)
             return;
-        MessageBox.Show(this, e.ErrorMessage, @"RDP Session Terminated");
+        MessageBox.Show(this, e.ErrorMessage, @"RDP Session Terminated", MessageBoxButtons.OK, MessageBoxIcon.Error);
+    }
+
+    private void FreeRdpControl_CertificateError(object sender, CertificateErrorEventArgs e)
+    {
+        if (MessageBox.Show(
+                this, 
+                @"The hostname of the server certificate does not match the provided host name. Do you want to ignore this error and try to connect again?", 
+                @"FreeRdp TLS handshake Error",
+                MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes) 
+            e.Continue();
     }
 
     private void ZoomInMenuItem_Click(object sender, EventArgs e)

--- a/src/RoyalApps.Community.FreeRdp.WinForms/CertificateErrorEventArgs.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/CertificateErrorEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace RoyalApps.Community.FreeRdp.WinForms;
+
+/// <summary>
+/// Event arguments for the CertificateError event
+/// </summary>
+public class CertificateErrorEventArgs : EventArgs
+{
+    private bool _continue;
+
+    internal bool ShouldContinue => _continue;
+    
+    /// <summary>
+    /// Ignores the error and continues. A new connection with /cert-ignore argument will be established.
+    /// </summary>
+    public void Continue()
+    {
+        _continue = true;
+    }
+}

--- a/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
@@ -32,8 +32,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="Resources\Images\RoyalApps_1024.png" Pack="true" PackagePath="\"/>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="Resources\Images\RoyalApps_1024.png" Pack="true" PackagePath="\" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<EmbeddedResource Include="Resources\Files\*.*" />
 	</ItemGroup>
 


### PR DESCRIPTION
Implemented: #3 
Event is raised when IgnoreCertificate was not set and a TLS handshake error is raised.
e.Continue(); can be called to retry the connection by setting IgnoreCertificate to true and connect again.