### PR TITLE
Implemented VerifyCredentials event

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The `DisconnectedEventArgs` may have an error code or error message for more inf
 
 The `CertificateError` event is raised when the TLS handshake failed. Calling `e.Continue();` in the event handler will set the `FreeRdpConfiguration.IgnoreCertificate` property to true and retries the connection.
 
+The `VerifyCredentials` event is raised when an authentication error occurs and the login fails. Calling `e.SetCredentials(string? username, string? domain, string? password);` in the event handler will set the credential properties in the `FreeRdpConfiguration` class and retries the connection with the provided credentials.
+
 ## Exploring the Demo Application
 The demo application is quite simple. The `Connection` menu has the following items:
 ### Connect

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.Designer.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.Designer.cs
@@ -95,6 +95,7 @@
             this.FreeRdpControl.Connected += FreeRdpControl_Connected;
             this.FreeRdpControl.Disconnected += FreeRdpControl_Disconnected;
             this.FreeRdpControl.CertificateError += FreeRdpControl_CertificateError;
+            this.FreeRdpControl.VerifyCredentials += FreeRdpControl_VerifyCredentials; 
             //
             // MenuStrip
             // 

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Product>RoyalApps.Community.FreeRdp.WinForms.Demo</Product>
     <Description>Demo app to test the FreeRDP control.</Description>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/CertificateErrorEventArgs.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/CertificateErrorEventArgs.cs
@@ -7,15 +7,13 @@ namespace RoyalApps.Community.FreeRdp.WinForms;
 /// </summary>
 public class CertificateErrorEventArgs : EventArgs
 {
-    private bool _continue;
+    internal bool ShouldContinue { get; private set; }
 
-    internal bool ShouldContinue => _continue;
-    
     /// <summary>
     /// Ignores the error and continues. A new connection with /cert-ignore argument will be established.
     /// </summary>
     public void Continue()
     {
-        _continue = true;
+        ShouldContinue = true;
     }
 }

--- a/src/RoyalApps.Community.FreeRdp.WinForms/VerifyCredentialsEventArgs.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/VerifyCredentialsEventArgs.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace RoyalApps.Community.FreeRdp.WinForms;
+
+/// <summary>
+/// Event arguments for the VerifyCredentials event
+/// </summary>
+public class VerifyCredentialsEventArgs : EventArgs
+{
+    internal bool CredentialsApplied { get; private set; }
+    internal string? Username { get; private set; }
+    internal string? Domain { get; private set; }
+    internal string? Password { get; private set; }
+    
+    /// <summary>
+    /// Set a username, domain and a password and try the connection again
+    /// </summary>
+    public void SetCredentials(string? username, string? domain, string? password)
+    {
+        Username = username;
+        Domain = domain;
+        Password = password;
+        CredentialsApplied = true;
+    }
+}


### PR DESCRIPTION
Implemented: #4 
The event is raised when an authentication error occurs and the login failed. Use the e.SetCredentials() method to provide new credentials and retry the connection.