### PR TITLE
Resolve `WFO1000` build warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,9 @@ jobs:
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.304
+        dotnet-version: '9.0'
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>RoyalApps.Community.FreeRdp.WinForms.Demo.Program</StartupObject>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/FreeRdpControl.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/FreeRdpControl.cs
@@ -41,11 +41,13 @@ public class FreeRdpControl : UserControl
     /// FreeRDP configuration settings 
     /// </summary>
     [Category("FreeRDP Settings"), Description("FreeRDP configuration settings.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public FreeRdpConfiguration Configuration { get; set; } = new();
 
     /// <summary>
     /// Logger instance
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ILogger Logger { get; set; } = DebugLoggerFactory.Create();
 
     /// <summary>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
@@ -16,7 +16,7 @@
         <LangVersion>10</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS8981;NU1701;WFO1000</NoWarn>
+        <NoWarn>$(NoWarn);CS8981;NU1701</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Resolve build warning/error (new in `net9.0`):

> Error WFO1000: Property 'ABC' does not configure the code serialization for its property content