### PR TITLE
Unambiguous .NET Framework version (contd.)

### DIFF
--- a/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
@@ -46,7 +46,7 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net4.7.2'">
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     </ItemGroup>
 


### PR DESCRIPTION
Use the same dotted-form .NET Framework version in `Condition`, too.