### PR TITLE
Strip UTF-8 BOM from source files

### DIFF
--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.Designer.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.FreeRdp.WinForms.Demo
+namespace RoyalApps.Community.FreeRdp.WinForms.Demo
 {
     partial class FreeRdpForm
     {

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Net;
 using System.Windows.Forms;

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.resx
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/FreeRdpForm.resx
@@ -1,4 +1,4 @@
-﻿<root>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/Program.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Demo;

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Product>RoyalApps.Community.FreeRdp.WinForms.Demo</Product>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Attributes/CommandLineArgumentAttribute.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Attributes/CommandLineArgumentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Attributes;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/CertificateErrorEventArgs.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/CertificateErrorEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.FreeRdp.WinForms;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/AudioRedirectionMode.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/AudioRedirectionMode.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
+namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
 
 /// <summary>
 /// Sets and retrieves the audio redirection mode and different audio redirection options.

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/BitsPerPixel.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/BitsPerPixel.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
+namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
 
 /// <summary>
 /// The color depth (in bits per pixel) for the control's connection.

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CacheConfiguration.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CacheConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CacheConfigurationTypeConverter.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CacheConfigurationTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CertificateConfiguration.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CertificateConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CertificateConfigurationTypeConverter.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/CertificateConfigurationTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/FreeRdpConfiguration.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/FreeRdpConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/FreeRdpConfigurationTypeConverter.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/FreeRdpConfigurationTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/GatewayConfiguration.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/GatewayConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/GatewayConfigurationTypeConverter.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/GatewayConfigurationTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/GdiRendering.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/GdiRendering.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/NetworkConnectionType.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/NetworkConnectionType.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/ProxyConfiguration.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/ProxyConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/ProxyConfigurationTypeConverter.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/ProxyConfigurationTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/ProxyMode.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/ProxyMode.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
+namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;
 
 /// <summary>
 /// The proxy mode for the FreeRdp connection

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/SecurityConfiguration.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/SecurityConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/SecurityConfigurationTypeConverter.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Configuration/SecurityConfigurationTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Configuration;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/DisconnectEventArgs.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/DisconnectEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.FreeRdp.WinForms;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Extensions/AssemblyExtensions.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Extensions/AssemblyExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/FreeRdpControl.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/FreeRdpControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Logging/DebugLogger.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Logging/DebugLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.Logging;

--- a/src/RoyalApps.Community.FreeRdp.WinForms/Logging/DebugLoggerFactory.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/Logging/DebugLoggerFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace RoyalApps.Community.FreeRdp.WinForms.Logging;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/ProcessJobTracker.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/ProcessJobTracker.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable CommentTypo
+// ReSharper disable CommentTypo
 
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license.

--- a/src/RoyalApps.Community.FreeRdp.WinForms/RdpErrorInfo.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RdpErrorInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Product>RoyalApps.Community.FreeRdp.WinForms</Product>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/VerifyCredentialsEventArgs.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/VerifyCredentialsEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.FreeRdp.WinForms;
 

--- a/src/RoyalApps.Community.FreeRdp.WinForms/WindowHelper.cs
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/WindowHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using Windows.Win32;

--- a/src/RoyalApps.Community.FreeRdp.slnx
+++ b/src/RoyalApps.Community.FreeRdp.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Folder Name="/Solution Items/">
     <File Path="..\.gitignore" />
     <File Path="..\README.md" />


### PR DESCRIPTION
The byte-order marks are not necessary on any platform -- C#, .NET and current IDEs handle UTF-8 files just fine without them.