### PR TITLE
Assorted enhancements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,10 +76,6 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
-
     # Build
     - name: build project
       run: dotnet build -c Release src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
 
     # Upload packages
     - name: Upload managed components
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: FreeRdp-nupkg
         path: ./*.nupkg

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NugetAudit>true</NugetAudit>
+    <NugetAuditMode>all</NugetAuditMode>
+    <NugetAuditLevel>low</NugetAuditLevel>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1506</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.264" />
+    <PackageVersion Include="Ookii.Dialogs.WinForms" Version="4.0.0" />
+    <PackageVersion Include="Simple.CredentialManager" Version="1.0.0" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ookii.Dialogs.WinForms" Version="4.0.0" />
-    <PackageReference Include="Simple.CredentialManager" Version="1.0.0" />
+    <PackageReference Include="Ookii.Dialogs.WinForms" />
+    <PackageReference Include="Simple.CredentialManager" />
   </ItemGroup>
 
 </Project>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
@@ -20,15 +20,15 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows;net4.7.2</TargetFrameworks>
-        <RuntimeIdentifier Condition="$(Platform) == 'x64'">win-x64</RuntimeIdentifier>
-        <RuntimeIdentifier Condition="$(Platform) == 'ARM64'">win-arm64</RuntimeIdentifier>
+        <TargetFramework>net10.0-windows</TargetFramework>
+        <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+        <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
         <UseWindowsForms>true</UseWindowsForms>
         <IncludeSymbols>true</IncludeSymbols>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <DebugType>pdbonly</DebugType>
         <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
@@ -40,27 +40,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.259">
+        <PackageReference Include="System.ComponentModel.Annotations" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Windows.CsWin32">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net4.7.2'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
+++ b/src/RoyalApps.Community.FreeRdp.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj
@@ -25,7 +25,6 @@
         <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
         <UseWindowsForms>true</UseWindowsForms>
         <IncludeSymbols>true</IncludeSymbols>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/src/RoyalApps.Community.FreeRdp.slnx
+++ b/src/RoyalApps.Community.FreeRdp.slnx
@@ -1,8 +1,10 @@
 <Solution>
   <Folder Name="/Solution Items/">
-    <File Path="..\.gitignore" />
-    <File Path="..\README.md" />
+    <File Path="../LICENSE" />
+    <File Path="../.gitignore" />
+    <File Path="../README.md" />
     <File Path=".editorconfig" />
+    <File Path="Directory.Packages.props" />
   </Folder>
   <Project Path="RoyalApps.Community.FreeRdp.WinForms.Demo\RoyalApps.Community.FreeRdp.WinForms.Demo.csproj" />
   <Project Path="RoyalApps.Community.FreeRDP.WinForms\RoyalApps.Community.FreeRdp.WinForms.csproj" />


### PR DESCRIPTION
Update projects to only target `net10.0`, dropping legacy .NET 9, 8 and Framework.

Enable NuGet Central Package Management (CPM) for consolidated dependency management.

Bump CsWin32.

Bump GH action versions.

Remove unused `setup-msbuild` GH action (building with `dotnet`)