### PR TITLE
Bump dependencies

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,7 @@
     <WarningsAsErrors>$(WarningsAsErrors);NU1506</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.264" />
     <PackageVersion Include="Ookii.Dialogs.WinForms" Version="4.0.0" />
     <PackageVersion Include="Simple.CredentialManager" Version="1.0.0" />

--- a/src/RoyalApps.Community.FreeRdp.slnx
+++ b/src/RoyalApps.Community.FreeRdp.slnx
@@ -6,6 +6,6 @@
     <File Path=".editorconfig" />
     <File Path="Directory.Packages.props" />
   </Folder>
-  <Project Path="RoyalApps.Community.FreeRdp.WinForms.Demo\RoyalApps.Community.FreeRdp.WinForms.Demo.csproj" />
-  <Project Path="RoyalApps.Community.FreeRDP.WinForms\RoyalApps.Community.FreeRdp.WinForms.csproj" />
+  <Project Path="RoyalApps.Community.FreeRdp.WinForms.Demo/RoyalApps.Community.FreeRdp.WinForms.Demo.csproj" />
+  <Project Path="RoyalApps.Community.FreeRDP.WinForms/RoyalApps.Community.FreeRdp.WinForms.csproj" />
 </Solution>


### PR DESCRIPTION
Bump dependencies (patch Tuesday 2026-01.)

Switch `.slnx` to forward slashes. Rider used backslashes previously, but this recently changed; update to match the current IDE. *(Cosmetic change; no functional impact.)*